### PR TITLE
Don't execute the transition if we're already in the final state

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
 export async function enter(element, transitionName = null) {
+    if(!element.classList.contains('hidden')) {
+      return
+    }
+
     element.classList.remove('hidden')
     await transition('enter', element, transitionName)
 }
 
 export async function leave(element, transitionName = null) {
+    if(element.classList.contains('hidden')) {
+      return
+    }
+
     await transition('leave', element, transitionName)
     element.classList.add('hidden')
 }


### PR DESCRIPTION
### Problem
If you trigger a leave transition when you are already hidden the transition still fires modifying the classes, even though the element is already hidden.

### Solution
Check if the element already has the `hidden` class and only trigger the transition if it isn't already in that state.