### PR TITLE
Handle overlap between initial classes and transition classes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/README.md
+++ b/README.md
@@ -54,11 +54,9 @@ When using dataset attributes el-transtion expects the following.
 * data-transtion-enter: Applied during the entire entering phase.
 * data-transition-enter-start: Added before element is inserted, removed one frame after element is inserted.
 * data-transition-enter-end: Added one frame after element is inserted (at the same time enter-start is removed), removed when transition/animation finishes.
-* data-transition-enter-stash: Removed before the element is inserted, added back in after transition is finished
 * data-transition-leave: Applied during the entire leaving phase.
 * data-transition-leave-start: Added immediately when a leaving transition is triggered, removed after one frame.
 * data-transition-leave-end: Added one frame after a leaving transition is triggered (at the same time leave-start is removed), removed when the transition/animation finishes.
-* data-transition-leave-stash: Removed when the leave trainsition is triggered, added back in after transition is finished
 
 
 ### Example 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ When using dataset attributes el-transtion expects the following.
 * data-transtion-enter: Applied during the entire entering phase.
 * data-transition-enter-start: Added before element is inserted, removed one frame after element is inserted.
 * data-transition-enter-end: Added one frame after element is inserted (at the same time enter-start is removed), removed when transition/animation finishes.
+* data-transition-enter-stash: Removed before the element is inserted, added back in after transition is finished
 * data-transition-leave: Applied during the entire leaving phase.
 * data-transition-leave-start: Added immediately when a leaving transition is triggered, removed after one frame.
 * data-transition-leave-end: Added one frame after a leaving transition is triggered (at the same time leave-start is removed), removed when the transition/animation finishes.
+* data-transition-leave-stash: Removed when the leave trainsition is triggered, added back in after transition is finished
 
 
 ### Example 

--- a/index.js
+++ b/index.js
@@ -21,13 +21,20 @@ async function transition(direction, element, animation) {
     const animationClass = animation ? `${animation}-${direction}` : direction
     let transition = `transition${direction.charAt(0).toUpperCase() + direction.slice(1)}`
     const genesis = dataset[transition] ? dataset[transition].split(" ") : [animationClass]
-    const stash = dataset[`${transition}Stash`] ? dataset[`${transition}Stash`].split(" ") : []
     const start = dataset[`${transition}Start`] ? dataset[`${transition}Start`].split(" ") : [`${animationClass}-start`]
     const end = dataset[`${transition}End`] ? dataset[`${transition}End`].split(" ") : [`${animationClass}-end`]
 
+    // if there's any overlap between the current set of classes and genesis/start/end,
+    // we should remove them before we start and add them back at the end
+    const stash = []
+    const current = new Set(element.classList.values())
+    genesis.forEach(cls => current.has(cls) && stash.push(cls))
+    start.forEach(cls => current.has(cls) && stash.push(cls))
+    end.forEach(cls => current.has(cls) && stash.push(cls))
+
+    removeClasses(element, stash)
     addClasses(element, genesis)
     addClasses(element, start)
-    removeClasses(element, stash)
     await nextFrame()
     removeClasses(element, start)
     addClasses(element, end);

--- a/index.js
+++ b/index.js
@@ -21,17 +21,20 @@ async function transition(direction, element, animation) {
     const animationClass = animation ? `${animation}-${direction}` : direction
     let transition = `transition${direction.charAt(0).toUpperCase() + direction.slice(1)}`
     const genesis = dataset[transition] ? dataset[transition].split(" ") : [animationClass]
+    const stash = dataset[`${transition}Stash`] ? dataset[`${transition}Stash`].split(" ") : []
     const start = dataset[`${transition}Start`] ? dataset[`${transition}Start`].split(" ") : [`${animationClass}-start`]
     const end = dataset[`${transition}End`] ? dataset[`${transition}End`].split(" ") : [`${animationClass}-end`]
 
     addClasses(element, genesis)
     addClasses(element, start)
+    removeClasses(element, stash)
     await nextFrame()
     removeClasses(element, start)
     addClasses(element, end);
     await afterTransition(element)
     removeClasses(element, end)
     removeClasses(element, genesis)
+    addClasses(element, stash)
 }
 
 function addClasses(element, classes) {


### PR DESCRIPTION
This work represents the changes needed to allow for more complicated element transitions. For example, transitioning from `opacity-0` to `opacity-50`:
```html
<!-- simplified example -->
<button class="hidden bg-black opacity-50"
              data-transition-enter="transition ease-out duration-100"
              data-transition-enter-start="opacity-0"
              data-transition-enter-end="opacity-50"
              data-transition-leave="transition ease-in duration-75"
              data-transition-leave-start="opacity-50"
              data-transition-leave-end="opacity-0"
              ></button
```
I first tried to use @jduff's PR (#2), but that didn't work in this case, as it isn't enough to not-remove the `opacity-50` at the end, you also have to make sure it isn't there throughout the transition, as if it is it overrides the `opacity-0`.

This PR implements a more general way of dealing with overlap between transition classes and initial classes, which should work in every case:

1. Before the start of the transition calculate any intersection between the transition classes and the initial classes, and remove them from the class list (some will be immediately added back in). We'll call these the stashed classes.
2. Run the transition as normal
3. Then add back in the stashed classes

