### PR TITLE
Use Element.getAnimations() to wait for transition completion vs. setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,12 +51,5 @@ function nextFrame() {
 }
 
 function afterTransition(element) {
-    return new Promise(resolve => {
-        // safari return string with comma separate values
-        const computedDuration = getComputedStyle(element).transitionDuration.split(",")[0]
-        const duration = Number(computedDuration.replace('s', '')) * 1000;
-        setTimeout(() => {
-            resolve()
-        }, duration)
-    });
+    return new Promise.all(element.getAnimations().map(animation => animation.finished));
 }

--- a/index.js
+++ b/index.js
@@ -51,5 +51,5 @@ function nextFrame() {
 }
 
 function afterTransition(element) {
-    return new Promise.all(element.getAnimations().map(animation => animation.finished));
+    return Promise.all(element.getAnimations().map(animation => animation.finished));
 }


### PR DESCRIPTION
This API covers CSS transitions + animations vs. transitions only and avoids the parsing shenanigans and setTimeout.

See https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations