### PR TITLE
Allow overriding of 'hidden'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,57 +1,67 @@
-export async function enter(element, transitionName = null, hideElement = true) {
-    hideElement && element.classList.remove('hidden')
-    await transition('enter', element, transitionName)
-    element.dataset.transitioned = true
+export async function enter(element, transitionName = null) {
+  await transition('enter', element, transitionName, 'leave')
+  element.dataset.transitioned = true
 }
 
-export async function leave(element, transitionName = null, hideElement = true) {
-    await transition('leave', element, transitionName)
-    hideElement && element.classList.add('hidden')
-    element.removeAttribute('transitioned')
+export async function leave(element, transitionName = null) {
+  if (!element.hasAttribute('data-transition-leave-final')) {
+    element.dataset.transitionLeaveFinal = 'hidden'
+  }
+
+  await transition('leave', element, transitionName, 'enter')
+  element.dataset.transitioned = false
 }
 
-export async function toggle(element, transitionName = null, hideElement = true) {
-    if (element.dataset.transitioned) {
-      await leave(element, transitionName)
-    } else {
-      await enter(element, transitionName)
-    }
+export async function toggle(element, transitionName = null) {
+  if (element.dataset.transitioned === 'true') {
+    await leave(element, transitionName)
+  } else {
+    await enter(element, transitionName)
+  }
 }
 
-async function transition(direction, element, animation) {
-    const dataset = element.dataset
-    const animationClass = animation ? `${animation}-${direction}` : direction
-    let transition = `transition${direction.charAt(0).toUpperCase() + direction.slice(1)}`
-    const genesis = dataset[transition] ? dataset[transition].split(" ") : [animationClass]
-    const start = dataset[`${transition}Start`] ? dataset[`${transition}Start`].split(" ") : [`${animationClass}-start`]
-    const end = dataset[`${transition}End`] ? dataset[`${transition}End`].split(" ") : [`${animationClass}-end`]
+async function transition(direction, element, animation, previousDirection) {
+  const dataset = element.dataset
+  const animationClass = animation ? `${animation}-${direction}` : direction
+  let transition = `transition${direction.charAt(0).toUpperCase() + direction.slice(1)}`
+  const genesis = dataset[transition] ? dataset[transition].split(" ") : [animationClass]
+  const start = dataset[`${transition}Start`] ? dataset[`${transition}Start`].split(" ") : [`${animationClass}-start`]
+  const end = dataset[`${transition}End`] ? dataset[`${transition}End`].split(" ") : [`${animationClass}-end`]
+  const final = dataset[`${transition}Final`] ? dataset[`${transition}Final`].split(" ") : [`${animationClass}-final`]
 
-    addClasses(element, genesis)
-    addClasses(element, start)
-    await nextFrame()
-    removeClasses(element, start)
-    addClasses(element, end);
-    await afterTransition(element)
-    removeClasses(element, end)
-    removeClasses(element, genesis)
+  const previousAnimationClass = animation ? `${animation}-${previousDirection}` : previousDirection
+  let previousTransition = `transition${previousDirection.charAt(0).toUpperCase() + previousDirection.slice(1)}`
+  const previousFinal = dataset[`${previousTransition}Final`] ? dataset[`${previousTransition}Final`].split(" ") : [`${previousAnimationClass}-final`]
+
+  removeClasses(element, previousFinal)
+  addClasses(element, genesis)
+  addClasses(element, start)
+  await nextFrame()
+  removeClasses(element, start)
+  addClasses(element, end);
+  await afterTransition(element)
+  removeClasses(element, end)
+  removeClasses(element, genesis)
+  await afterTransition(element)
+  addClasses(element, final)
 }
 
 function addClasses(element, classes) {
-    element.classList.add(...classes)
+  element.classList.add(...classes)
 }
 
 function removeClasses(element, classes) {
-    element.classList.remove(...classes)
+  element.classList.remove(...classes)
 }
 
 function nextFrame() {
-    return new Promise(resolve => {
-        requestAnimationFrame(() => {
-            requestAnimationFrame(resolve)
-        });
+  return new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(resolve)
     });
+  });
 }
 
 function afterTransition(element) {
-    return Promise.all(element.getAnimations().map(animation => animation.finished));
+  return Promise.all(element.getAnimations().map(animation => animation.finished));
 }

--- a/index.js
+++ b/index.js
@@ -1,18 +1,20 @@
-export async function enter(element, transitionName = null) {
-    element.classList.remove('hidden')
+export async function enter(element, transitionName = null, hideElement = true) {
+    hideElement && element.classList.remove('hidden')
     await transition('enter', element, transitionName)
+    element.dataset.transitioned = true
 }
 
-export async function leave(element, transitionName = null) {
+export async function leave(element, transitionName = null, hideElement = true) {
     await transition('leave', element, transitionName)
-    element.classList.add('hidden')
+    hideElement && element.classList.add('hidden')
+    element.removeAttribute('transitioned')
 }
 
-export async function toggle(element, transitionName = null) {
-    if (element.classList.contains('hidden')) {
-        await enter(element, transitionName)
+export async function toggle(element, transitionName = null, hideElement = true) {
+    if (element.dataset.transitioned) {
+      await leave(element, transitionName)
     } else {
-        await leave(element, transitionName)
+      await enter(element, transitionName)
     }
 }
 


### PR DESCRIPTION
I'm not sure if this adds too much complexity to the library, but, for my uses, I didn't want a 'hidden' class added to the end of every leave transition. This would allow the library to be used for simple animations that don't result in visibility changes. I went through a couple iterations with the goal of preserving the same invocation syntax, except now it checks for two additional data attributes.

This PR adds `data-transition-enter-final` and `data-transition-leave-final`. These classes get added at the end of their respective directions, and get removed at the beginning of their opposition directions. It preserves the `hidden` default by adding a default `data-transition-leave-final` attribute of `hidden`.

`enter()` and `leave()` now track their last status by settings a `data-transitioned` attribute, rather than the presence of css classes. With the presence of potential multiple `transition-leave-final` classes, checking the transitioned status would be complicated. I thought leveraging another data attribute would be more precise and consistent.

I understand if this is more complicated than you want to make the library, but I wanted to at least make a PR in case you found it valuable to add this extra flexibility. Javascript is not my primary language so also completely happy to make syntax changes if you like the functionality but not the look!